### PR TITLE
feat: cache comments and use session-based auth

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+MONGO_URI=mongodb://mongo:27017/blog
+PORT=4000
+CLIENT_URL=http://localhost:5173
+SESSION_SECRET=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+backend/node_modules
+frontend/node_modules
+backend/dist
+frontend/dist

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.RECIPEPREFIX = >
+.PHONY: build build-backend-dev build-frontend-dev build-dev up down dev dev-down
+
+build:
+> docker build -t blog-backend -f backend/Dockerfile .
+
+build-backend-dev:
+> docker build -t blog-backend-dev -f backend/Dockerfile.dev .
+
+build-frontend-dev:
+> docker build -t blog-frontend-dev -f frontend/Dockerfile.dev frontend
+
+build-dev: build-backend-dev build-frontend-dev
+
+up: build
+> docker-compose up -d
+
+down:
+> docker-compose down
+
+dev:
+> docker-compose -f docker-compose.dev.yaml up
+
+dev-down:
+> docker-compose -f docker-compose.dev.yaml down

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-***Blog***
+# Blog
+
+Full-stack blogging application with Node.js, Express, MongoDB and a React frontend.
+
+## Production
+
+Build the backend (which bundles the frontend) and start services:
+
+```
+make up
+```
+
+Stop services:
+
+```
+make down
+```
+
+## Development
+
+Build the development images:
+
+```
+make build-dev
+```
+
+Run hot-reloading backend, Vite dev server and MongoDB:
+
+```
+make dev
+```
+
+Stop the development stack:
+
+```
+make dev-down
+```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:18-alpine AS frontend-build
+WORKDIR /app
+COPY frontend/package*.json frontend/tsconfig.json frontend/tsconfig.node.json frontend/vite.config.ts frontend/index.html frontend/
+RUN npm --prefix frontend install
+COPY frontend/src frontend/src
+RUN npm --prefix frontend run build
+
+FROM node:18-alpine AS backend-build
+WORKDIR /app
+COPY backend/package*.json backend/tsconfig.json backend/
+RUN npm --prefix backend install
+COPY backend/src backend/src
+RUN npm --prefix backend run build
+
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=backend-build /app/backend/dist ./dist
+COPY --from=backend-build /app/backend/node_modules ./node_modules
+COPY --from=frontend-build /app/frontend/dist ./dist/public
+COPY backend/package.json .
+ENV NODE_ENV=production
+EXPOSE 4000
+CMD ["node", "dist/index.js"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY backend/package*.json backend/tsconfig.json ./
+RUN npm install
+COPY backend .
+CMD ["npm", "run", "dev"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "blog-backend",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "node dist/index.js",
+    "build": "tsc",
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "migrate": "ts-node src/migrate.ts",
+    "test": "npm run build"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "express-validator": "^6.15.0",
+    "mongoose": "^7.5.0",
+    "express-session": "^1.17.3",
+    "connect-mongo": "^4.6.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.1.6",
+    "@types/express-session": "^1.17.6"
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,58 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import session from 'express-session';
+import MongoStore from 'connect-mongo';
+import dotenv from 'dotenv';
+import path from 'path';
+import authRoutes from './routes/auth';
+import postRoutes from './routes/posts';
+import { migrate } from './migrate';
+
+dotenv.config();
+
+const app = express();
+app.use(
+  cors({ origin: process.env.CLIENT_URL || true, credentials: true })
+);
+app.use(express.json());
+
+const mongoUri = process.env.MONGO_URI || 'mongodb://localhost:27017/blog';
+
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'secret',
+    resave: false,
+    saveUninitialized: false,
+    store: MongoStore.create({ mongoUrl: mongoUri }),
+    cookie: {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+    },
+  })
+);
+
+mongoose
+  .connect(mongoUri)
+  .then(async () => {
+    console.log('MongoDB connected');
+    await migrate();
+  })
+  .catch((err) => console.error('MongoDB connection error', err));
+
+app.use('/api/auth', authRoutes);
+app.use('/api/posts', postRoutes);
+
+if (process.env.NODE_ENV === 'production') {
+  const publicPath = path.join(__dirname, 'public');
+  app.use(express.static(publicPath));
+  app.get('*', (_req, res) => {
+    res.sendFile(path.join(publicPath, 'index.html'));
+  });
+}
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+import session from 'express-session';
+
+export interface AuthRequest extends Request {
+  session: session.Session & { userId?: string };
+  user?: any;
+}
+
+export default function (req: AuthRequest, res: Response, next: NextFunction) {
+  if (!req.session?.userId) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  req.user = { userId: req.session.userId };
+  next();
+}

--- a/backend/src/migrate.ts
+++ b/backend/src/migrate.ts
@@ -1,0 +1,25 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import Post from './models/Post';
+import User from './models/User';
+
+dotenv.config();
+
+export async function migrate() {
+  await Promise.all([Post.syncIndexes(), User.syncIndexes()]);
+}
+
+if (require.main === module) {
+  const mongoUri = process.env.MONGO_URI || 'mongodb://localhost:27017/blog';
+  mongoose
+    .connect(mongoUri)
+    .then(async () => {
+      await migrate();
+      await mongoose.disconnect();
+      console.log('Migration completed');
+    })
+    .catch((err) => {
+      console.error('Migration failed', err);
+      process.exit(1);
+    });
+}

--- a/backend/src/models/Comment.ts
+++ b/backend/src/models/Comment.ts
@@ -1,0 +1,17 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface ICommentDoc extends Document {
+  post: Schema.Types.ObjectId;
+  user: Schema.Types.ObjectId;
+  text: string;
+  createdAt: Date;
+}
+
+const CommentSchema = new Schema<ICommentDoc>({
+  post: { type: Schema.Types.ObjectId, ref: 'Post', required: true },
+  user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  text: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now }
+});
+
+export default mongoose.model<ICommentDoc>('Comment', CommentSchema);

--- a/backend/src/models/Post.ts
+++ b/backend/src/models/Post.ts
@@ -1,0 +1,31 @@
+import mongoose, { Schema, Document, Types } from 'mongoose';
+
+export interface IComment {
+  user: Types.ObjectId;
+  text: string;
+  createdAt: Date;
+}
+
+export interface IPost extends Document {
+  title: string;
+  description: string;
+  createdAt: Date;
+  tags: string[];
+  comments: IComment[];
+}
+
+const CommentSchema = new Schema<IComment>({
+  user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  text: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now }
+});
+
+const PostSchema = new Schema<IPost>({
+  title: { type: String, required: true },
+  description: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+  tags: [{ type: String }],
+  comments: [CommentSchema]
+});
+
+export default mongoose.model<IPost>('Post', PostSchema);

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -1,0 +1,13 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IUser extends Document {
+  username: string;
+  password: string;
+}
+
+const UserSchema: Schema = new Schema<IUser>({
+  username: { type: String, required: true, unique: true },
+  password: { type: String, required: true }
+});
+
+export default mongoose.model<IUser>('User', UserSchema);

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,65 @@
+import { Router } from 'express';
+import bcrypt from 'bcryptjs';
+import { body, validationResult } from 'express-validator';
+import User from '../models/User';
+
+const router = Router();
+
+router.post(
+  '/register',
+  [
+    body('username').notEmpty(),
+    body('password').isLength({ min: 6 }).matches(/^[A-Za-z0-9]+$/)
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+    const { username, password } = req.body;
+    try {
+      let user = await User.findOne({ username });
+      if (user) return res.status(400).json({ message: 'User already exists' });
+      const salt = await bcrypt.genSalt(10);
+      const hashed = await bcrypt.hash(password, salt);
+      user = new User({ username, password: hashed });
+      await user.save();
+      res.json({ message: 'Registered successfully' });
+    } catch (err) {
+      res.status(500).send('Server error');
+    }
+  }
+);
+
+router.post(
+  '/login',
+  [body('username').notEmpty(), body('password').exists()],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+    const { username, password } = req.body;
+    try {
+      const user = await User.findOne({ username });
+      if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+      const isMatch = await bcrypt.compare(password, user.password);
+      if (!isMatch) return res.status(400).json({ message: 'Invalid credentials' });
+      (req.session as any).userId = user.id;
+      res.json({ message: 'Logged in' });
+    } catch (err) {
+      res.status(500).send('Server error');
+    }
+  }
+);
+
+router.post('/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.clearCookie('connect.sid');
+    res.json({ message: 'Logged out' });
+  });
+});
+
+router.get('/me', async (req, res) => {
+  if (!req.session.userId) return res.status(401).json({ message: 'Unauthorized' });
+  const user = await User.findById(req.session.userId).select('-password');
+  res.json(user);
+});
+
+export default router;

--- a/backend/src/routes/posts.ts
+++ b/backend/src/routes/posts.ts
@@ -1,0 +1,144 @@
+import { Router } from 'express';
+import { body, validationResult } from 'express-validator';
+import Post from '../models/Post';
+import Comment from '../models/Comment';
+import auth, { AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+// Create post
+router.post(
+  '/',
+  auth,
+  [body('title').notEmpty(), body('description').notEmpty()],
+  async (req: AuthRequest, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+    try {
+      const { title, description, tags } = req.body;
+      const post = new Post({ title, description, tags });
+      await post.save();
+      res.status(201).json(post);
+    } catch (err) {
+      res.status(500).send('Server error');
+    }
+  }
+);
+
+// Get posts with filtering/search/sorting
+router.get('/', async (req, res) => {
+  const { search, tags, sort = 'createdAt', order = 'desc' } = req.query as any;
+  const query: any = {};
+  if (search) {
+    query.$or = [
+      { title: { $regex: search, $options: 'i' } },
+      { description: { $regex: search, $options: 'i' } }
+    ];
+  }
+  if (tags) {
+    query.tags = { $in: (tags as string).split(',') };
+  }
+  try {
+    const posts = await Post.find(query).sort({ [sort]: order === 'desc' ? -1 : 1 });
+    res.json(posts);
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+});
+
+// Get single post
+router.get('/:id', async (req, res) => {
+  try {
+    const post = await Post.findById(req.params.id);
+    if (!post) return res.status(404).json({ message: 'Post not found' });
+    res.json(post);
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+});
+
+// Update post
+router.put(
+  '/:id',
+  auth,
+  [body('title').notEmpty(), body('description').notEmpty()],
+  async (req: AuthRequest, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+    try {
+      const { title, description, tags } = req.body;
+      const post = await Post.findByIdAndUpdate(
+        req.params.id,
+        { title, description, tags },
+        { new: true }
+      );
+      if (!post) return res.status(404).json({ message: 'Post not found' });
+      res.json(post);
+    } catch (err) {
+      res.status(500).send('Server error');
+    }
+  }
+);
+
+// Delete post
+router.delete('/:id', auth, async (req: AuthRequest, res) => {
+  try {
+    const post = await Post.findByIdAndDelete(req.params.id);
+    if (!post) return res.status(404).json({ message: 'Post not found' });
+    res.json({ message: 'Post removed' });
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+});
+
+// Add comment
+router.post(
+  '/:id/comments',
+  auth,
+  [body('text').notEmpty()],
+  async (req: AuthRequest, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+    try {
+      const post = await Post.findById(req.params.id);
+      if (!post) return res.status(404).json({ message: 'Post not found' });
+      const comment = new Comment({
+        post: post._id,
+        user: req.user.userId,
+        text: req.body.text,
+      });
+      await comment.save();
+      post.comments.push({ user: comment.user, text: comment.text, createdAt: comment.createdAt } as any);
+      if (post.comments.length > 20) {
+        post.comments = post.comments.slice(-20);
+      }
+      await post.save();
+      res.json(comment);
+    } catch (err) {
+      res.status(500).send('Server error');
+    }
+  }
+);
+
+// Get comments with fallback to collection
+router.get('/:id/comments', async (req, res) => {
+  const { skip = 0, limit = 20 } = req.query as any;
+  try {
+    const post = await Post.findById(req.params.id);
+    if (!post) return res.status(404).json({ message: 'Post not found' });
+    const s = parseInt(skip, 10);
+    const l = parseInt(limit, 10);
+    if (s < post.comments.length) {
+      return res.json(post.comments.slice(s, s + l));
+    }
+    const comments = await Comment.find({ post: post._id })
+      .sort({ createdAt: 1 })
+      .skip(s - post.comments.length)
+      .limit(l);
+    res.json(comments);
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+});
+
+export default router;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "commonjs",
+    "target": "es2019",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,34 @@
+version: '3.9'
+services:
+  mongo:
+    image: mongo:6
+    ports:
+      - '27017:27017'
+    volumes:
+      - mongo-data:/data/db
+  backend:
+    image: blog-backend-dev
+    env_file:
+      - .env
+    ports:
+      - '4000:4000'
+    volumes:
+      - ./backend:/app
+      - /app/node_modules
+    command: npm run dev
+    depends_on:
+      - mongo
+  frontend:
+    image: blog-frontend-dev
+    ports:
+      - '5173:5173'
+    environment:
+      - VITE_API_URL=http://localhost:4000/api
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    command: npm run dev -- --host --port 5173
+    depends_on:
+      - backend
+volumes:
+  mongo-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: '3.9'
+services:
+  mongo:
+    image: mongo:6
+    ports:
+      - '27017:27017'
+    volumes:
+      - mongo-data:/data/db
+  backend:
+    image: blog-backend
+    env_file:
+      - .env
+    ports:
+      - '4000:4000'
+    depends_on:
+      - mongo
+volumes:
+  mongo-data:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json tsconfig.json tsconfig.node.json vite.config.ts index.html ./
+RUN npm install
+COPY src ./src
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "--port", "5173"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blog Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "blog-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "npm run build"
+  },
+  "dependencies": {
+    "axios": "^1.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.16.0",
+    "@tanstack/react-query": "^4.35.0",
+    "@tanstack/react-query-devtools": "^4.35.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^1.2.1",
+    "tailwind-merge": "^1.14.0",
+    "@radix-ui/react-slot": "^1.0.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.1.6",
+    "vite": "^4.4.9",
+    "tailwindcss": "^3.3.3",
+    "postcss": "^8.4.27",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,30 @@
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { AuthContext } from './context/AuthContext';
+import NavBar from './components/NavBar';
+import Landing from './pages/Landing';
+import Login from './pages/Login';
+import Register from './pages/Register';
+import Posts from './pages/Posts';
+import PostDetail from './pages/PostDetail';
+import PostForm from './pages/PostForm';
+
+function App() {
+  const { user } = useContext(AuthContext);
+  return (
+    <BrowserRouter>
+      <NavBar />
+      <Routes>
+        <Route path="/" element={<Landing />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route path="/posts" element={<Posts />} />
+        <Route path="/posts/new" element={user ? <PostForm /> : <Navigate to="/login" />} />
+        <Route path="/posts/:id/edit" element={user ? <PostForm /> : <Navigate to="/login" />} />
+        <Route path="/posts/:id" element={<PostDetail />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || '/api',
+  withCredentials: true,
+});
+
+export default api;

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,0 +1,34 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { AuthContext } from '../context/AuthContext';
+import { Button } from './ui/button';
+
+const NavBar: React.FC = () => {
+  const { user, logout } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
+
+  return (
+    <nav>
+      <Link to="/">Home</Link> | <Link to="/posts">Posts</Link>
+      {user ? (
+        <>
+          {' '}
+          | <Link to="/posts/new">New Post</Link> |{' '}
+          <Button onClick={handleLogout}>Logout</Button>
+        </>
+      ) : (
+        <>
+          {' '}
+          | <Link to="/login">Login</Link> | <Link to="/register">Register</Link>
+        </>
+      )}
+    </nav>
+  );
+};
+
+export default NavBar;

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:pointer-events-none bg-primary text-primary-foreground hover:bg-primary/90 h-10 py-2 px-4',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-600 text-white hover:bg-blue-700',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant }), className)}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,48 @@
+import { createContext } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import api from '../api';
+
+interface User {
+  _id: string;
+  username: string;
+}
+
+interface AuthContextType {
+  user?: User;
+  login: (username: string, password: string) => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextType>({
+  login: () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const queryClient = useQueryClient();
+  const { data: user } = useQuery<User | undefined>(['me'], async () => {
+    const res = await api.get('/auth/me');
+    return res.data;
+  }, { retry: false });
+
+  const loginMutation = useMutation({
+    mutationFn: (vars: { username: string; password: string }) =>
+      api.post('/auth/login', vars),
+    onSuccess: () => queryClient.invalidateQueries(['me']),
+  });
+
+  const logoutMutation = useMutation({
+    mutationFn: () => api.post('/auth/logout'),
+    onSuccess: () => queryClient.invalidateQueries(['me']),
+  });
+
+  const login = (username: string, password: string) =>
+    loginMutation.mutate({ username, password });
+  const logout = () => logoutMutation.mutate();
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: any[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { AuthProvider } from './context/AuthContext';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import './index.css';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,0 +1,8 @@
+const Landing: React.FC = () => (
+  <div>
+    <h1>Welcome to the Blog</h1>
+    <p>Read and share posts with the community.</p>
+  </div>
+);
+
+export default Landing;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,28 @@
+import { FormEvent, useContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { Button } from '../components/ui/button';
+
+const Login: React.FC = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const { login } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    login(username, password);
+    navigate('/posts');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Login</h2>
+      <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <Button type="submit">Login</Button>
+    </form>
+  );
+};
+
+export default Login;

--- a/frontend/src/pages/PostDetail.tsx
+++ b/frontend/src/pages/PostDetail.tsx
@@ -1,0 +1,74 @@
+import { FormEvent, useContext, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../api';
+import { AuthContext } from '../context/AuthContext';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { Button } from '../components/ui/button';
+
+interface Comment {
+  _id: string;
+  text: string;
+}
+
+interface Post {
+  _id: string;
+  title: string;
+  description: string;
+  comments: Comment[];
+}
+
+const PostDetail: React.FC = () => {
+  const { id } = useParams();
+  const { user } = useContext(AuthContext);
+  const [text, setText] = useState('');
+  const [comments, setComments] = useState<Comment[]>([]);
+
+  const { data: post } = useQuery<Post>(['post', id], async () => {
+    const res = await api.get(`/posts/${id}`);
+    setComments(res.data.comments || []);
+    return res.data;
+  });
+
+  const commentMutation = useMutation({
+    mutationFn: () => api.post(`/posts/${id}/comments`, { text }),
+    onSuccess: (res) => {
+      setComments((prev) => [...prev, res.data]);
+      setText('');
+    },
+  });
+
+  const loadMore = async () => {
+    const res = await api.get(`/posts/${id}/comments`, {
+      params: { skip: comments.length },
+    });
+    setComments((prev) => {
+      const ids = new Set(prev.map((c) => c._id));
+      const next = res.data.filter((c: Comment) => !ids.has(c._id));
+      return [...prev, ...next];
+    });
+  };
+
+  if (!post) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>{post.title}</h2>
+      <p>{post.description}</p>
+      <h3>Comments</h3>
+      <ul>
+        {comments.map((c, i) => (
+          <li key={i}>{c.text}</li>
+        ))}
+      </ul>
+      <Button onClick={loadMore}>Load more</Button>
+      {user && (
+        <form onSubmit={(e: FormEvent) => { e.preventDefault(); commentMutation.mutate(); }}>
+          <input value={text} onChange={(e) => setText(e.target.value)} />
+          <Button type="submit">Add Comment</Button>
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default PostDetail;

--- a/frontend/src/pages/PostForm.tsx
+++ b/frontend/src/pages/PostForm.tsx
@@ -1,0 +1,49 @@
+import { FormEvent, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import api from '../api';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { Button } from '../components/ui/button';
+
+const PostForm: React.FC = () => {
+  const { id } = useParams();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+  const navigate = useNavigate();
+
+  useQuery(['post', id], async () => {
+    const res = await api.get(`/posts/${id}`);
+    setTitle(res.data.title);
+    setDescription(res.data.description);
+    setTags((res.data.tags || []).join(','));
+    return res.data;
+  }, { enabled: !!id });
+
+  const mutation = useMutation({
+    mutationFn: (payload: any) =>
+      id ? api.put(`/posts/${id}`, payload) : api.post('/posts', payload),
+    onSuccess: () => navigate('/posts'),
+  });
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const payload = {
+      title,
+      description,
+      tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
+    };
+    mutation.mutate(payload);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>{id ? 'Edit' : 'New'} Post</h2>
+      <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" />
+      <textarea value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Description" />
+      <input value={tags} onChange={(e) => setTags(e.target.value)} placeholder="Tags (comma separated)" />
+      <Button type="submit">Save</Button>
+    </form>
+  );
+};
+
+export default PostForm;

--- a/frontend/src/pages/Posts.tsx
+++ b/frontend/src/pages/Posts.tsx
@@ -1,0 +1,48 @@
+import { useContext } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../api';
+import { AuthContext } from '../context/AuthContext';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button } from '../components/ui/button';
+
+interface Post {
+  _id: string;
+  title: string;
+}
+
+const Posts: React.FC = () => {
+  const { user } = useContext(AuthContext);
+  const queryClient = useQueryClient();
+  const { data: posts = [] } = useQuery<Post[]>(['posts'], async () => {
+    const res = await api.get('/posts');
+    return res.data;
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/posts/${id}`),
+    onSuccess: () => queryClient.invalidateQueries(['posts']),
+  });
+
+  const deletePost = (id: string) => deleteMutation.mutate(id);
+
+  return (
+    <div>
+      <h2>Posts</h2>
+      <ul>
+        {posts.map((p) => (
+          <li key={p._id}>
+            <Link to={`/posts/${p._id}`}>{p.title}</Link>
+            {user && (
+              <>
+                {' '}| <Link to={`/posts/${p._id}/edit`}>Edit</Link> |{' '}
+                <Button onClick={() => deletePost(p._id)}>Delete</Button>
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Posts;

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,0 +1,30 @@
+import { FormEvent, useContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { Button } from '../components/ui/button';
+import api from '../api';
+
+const Register: React.FC = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const { login } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await api.post('/auth/register', { username, password });
+    login(username, password);
+    navigate('/posts');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Register</h2>
+      <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <Button type="submit">Register</Button>
+    </form>
+  );
+};
+
+export default Register;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- move all comments into a dedicated collection and cache only the latest 20 on each post
- replace JWT auth with secure session cookies and alphanumeric password checks
- style the React frontend with shadcn components and power data fetching via TanStack Query

## Testing
- `npm install` (backend) *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fexpress-session)*
- `npm test` (backend) *(fails: Cannot find module 'express' or its corresponding type declarations)*
- `npm install` (frontend) *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-slot)*
- `npm test` (frontend) *(fails: Cannot find module 'react-router-dom' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688de5f9b5ec8322b2ec69e095a0e87e